### PR TITLE
Fix token parsing for BA_ section

### DIFF
--- a/canmatrix/dbc.py
+++ b/canmatrix/dbc.py
@@ -652,7 +652,7 @@ def load(f, **options):
                                     temp_raw.group(2).decode(dbcImportEncoding))
 
         elif decoded.startswith("BA_ "):
-            regexp = re.compile("^BA\_ +\"[A-Za-z0-9\-_]+\" +(.+)")
+            regexp = re.compile("^BA\_ +\"[A-Za-z0-9[-_ .]+\" +(.+)")
             tempba = regexp.match(decoded)
 
             if tempba.group(1).strip().startswith("BO_ "):


### PR DESCRIPTION
Previously there was an issue with token parsing in the _BA section of DBC files. If the parser ran into a '[' or ']' within quotes then it would cough. This commit fixes this bug and allows the parser to work for these cases.