### PR TITLE
Removes the functionality to intelligently calculate the startbit for…

### DIFF
--- a/canmatrix/dbc.py
+++ b/canmatrix/dbc.py
@@ -455,9 +455,9 @@ def load(f, **options):
                                      dbcImportEncoding),
                                  receiver=receiver,
                                  multiplex=multiplex)
-                if not tempSig.is_little_endian:
+                #if not tempSig.is_little_endian:
                     # startbit of motorola coded signals are MSB in dbc
-                    tempSig.setStartbit(int(temp.group(3)), bitNumbering=1)
+                    #tempSig.setStartbit(int(temp.group(3)), bitNumbering=1)
 
                 db._fl.addSignalToLastFrame(tempSig)
 


### PR DESCRIPTION
… Big endian

The higher level code uses the default startbit location (most signifigant bit) to calculate big endian values. This extra logic is not necessary and causes problems.